### PR TITLE
Updated chart with probes and latest image

### DIFF
--- a/services/sbom_resolver/service/deploy/k8_helm/sbom-resolver/Chart.yaml
+++ b/services/sbom_resolver/service/deploy/k8_helm/sbom-resolver/Chart.yaml
@@ -12,4 +12,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.17
+appVersion: 1.0.18

--- a/services/sbom_resolver/service/deploy/k8_helm/sbom-resolver/templates/deployment.yaml
+++ b/services/sbom_resolver/service/deploy/k8_helm/sbom-resolver/templates/deployment.yaml
@@ -53,6 +53,20 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /resolver/alpine/v1/liveness
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 4
+          readinessProbe:
+            httpGet:
+              path: /resolver/alpine/v1/readyness
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 1
           env:
             - name: APORTS_SRC
               value: /mnt/alpine/src


### PR DESCRIPTION
- Added liveness and rediness probe to chart.
- Update chart to the latest image.

Failurethreshold is set high to accommodate for the fact that the service is still single threaded. We don't want to kill the container because of a long running operation.

The readiness probe however will stop new requests to the pod if the pod i busy processing a long running request. 