### PR TITLE
Added gunicorn side by side with uwsgi

### DIFF
--- a/services/sbom_resolver/service/build/Containerfile
+++ b/services/sbom_resolver/service/build/Containerfile
@@ -9,12 +9,13 @@ LABEL org.opencontainers.image.authors=hans.thorsen@ericsson.com
 
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 
-COPY Makefile.bootstrap /Makefile.bootstrap
-COPY entrypoint.sh /entrypoint.sh
 
 COPY bomres /src
 RUN pip3 install /src
+
+# Two candidates , not yet integrated , the development server is currently used in production
 RUN pip3 install uwsgi
+RUN pip3 install gunicorn
 
 COPY service /service
 WORKDIR /service
@@ -24,8 +25,13 @@ RUN chmod u+x,g+x /entrypoint.sh; \
     openssl rsa -in priv.pem -pubout > pub.pem; \
     rm -rf /src
 
+COPY Makefile.bootstrap /Makefile.bootstrap
+COPY entrypoint.sh /entrypoint.sh
+RUN  chmod u+x,g+x,o+x  /entrypoint.sh
+
 EXPOSE 8080
 
 ENTRYPOINT ["/entrypoint.sh"]
 
+# Currently the singlethreaded development server
 CMD [ "server"]

--- a/services/sbom_resolver/service/build/Makefile
+++ b/services/sbom_resolver/service/build/Makefile
@@ -32,8 +32,13 @@ python:
 
 run:
 	docker run -i -t  $(OPTIONS)  $(CONTAINER_IMAGE) server
+
 uwsgi:
 	docker run -i -t  $(OPTIONS)  $(CONTAINER_IMAGE) uwsgi
+
+gunicorn:
+	docker run -i -t  $(OPTIONS)  $(CONTAINER_IMAGE) gunicorn
+
 sh:
 	docker run -i -t  $(OPTIONS)  $(CONTAINER_IMAGE) sh
 

--- a/services/sbom_resolver/service/build/entrypoint.sh
+++ b/services/sbom_resolver/service/build/entrypoint.sh
@@ -68,6 +68,8 @@ elif [ "$1" = 'server' ]; then
    exec python3 app.py
 elif [ "$1" = 'uwsgi' ]; then
    exec uwsgi --socket 0.0.0.0:8080 --protocol=http --wsgi-file wsgi.py --master --processes 4 --threads 2
+elif [ "$1" = 'gunicorn' ]; then
+   exec gunicorn -b:8080 --workers=2 wsgi:application
 else
     exec "$@"
 fi


### PR DESCRIPTION
There are now three options to start bom_resolver as a service 


 exec python3 app.py
 exec uwsgi --socket 0.0.0.0:8080 --protocol=http --wsgi-file wsgi.py --master --processes 4 --threads 2
 exec gunicorn -b:8080 --workers=2 wsgi:application

https://medium.com/django-deployment/which-wsgi-server-should-i-use-a70548da6a83
