### PR TITLE
Added simple webserver to reference suite in desired SBOM

### DIFF
--- a/services/sbom_resolver/service/build/TODO.txt
+++ b/services/sbom_resolver/service/build/TODO.txt
@@ -163,8 +163,31 @@ lua5.3
 zip
    zip${_pkgver}.tar.gz
 
+#7 openldap and childs 
+"childs": [],
+
+#7  Conflict. The container name "/alpine3.14" is already in use by container  
+docker run --rm -i  --name alpine3.14 alpine_sandbox_base_os:3.14.1  /bin/sh -c 'apk info -v 2> /dev/null' > sbom/os.apk
+
+#8 depends with version 
+
+pkgname=busybox-initscripts
+depends="busybox openrc>=0.24.1-r6"
 
 
+busybox/APKBUILD
+replaces="busybox-initscripts"
 
+#9 Download main dependencies if only subdepency is included 
+
+libbz2 is a child of bzip2 
+
+#10 relaces keyword 
+
+https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10724
+
+See APKBUILD for openssl and lighttp 
+
+ 
 
 

--- a/tools/base_os_alpine/build/Makefile
+++ b/tools/base_os_alpine/build/Makefile
@@ -64,12 +64,12 @@ $(PAYLOAD_CONTAINER_FILE) :
 public_build:  $(PAYLOAD_CONTAINER_FILE)
 	docker run --rm $(BUILDER_IMAGE) -a $(ARCH)  -b -s -t UTC -r v$(ALPINE_VERSION) -m $(REPO_URL)  -p $(PACKAGE_LIST)   > $(BUILD_DIR)/rootfs.tar.gz
 	cd $(BUILD_DIR) && docker build -t $(CONTAINER_IMAGE) -f Containerfile .
-	docker run --rm -i  --name alpine$(ALPINE_VERSION) $(CONTAINER_IMAGE)  /bin/sh -c 'apk info -v 2> /dev/null' > sbom/os.apk
+	docker run --rm -i  $(CONTAINER_IMAGE)  /bin/sh -c 'apk info -v 2> /dev/null' > sbom/os.apk
 
 private_build:  $(PAYLOAD_CONTAINER_FILE)
 	docker run -v "$$PWD/download/alpine/:/download"  --rm $(BUILDER_IMAGE)  -a  $(ARCH)  -b -s -t UTC -r v$(ALPINE_VERSION) -m /download -p $(PACKAGE_LIST)   > $(BUILD_DIR)/rootfs.tar.gz
 	cd $(BUILD_DIR) && docker build -t $(CONTAINER_IMAGE)  -f Containerfile  .
-	docker run --rm -i  --name alpine$(ALPINE_VERSION) $(CONTAINER_IMAGE)  /bin/sh -c '/usr/local/bin/bom.sh 2> /dev/null' > sbom/os.bom
+	docker run --rm -i   $(CONTAINER_IMAGE)  /bin/sh -c '/usr/local/bin/bom.sh 2> /dev/null' > sbom/os.bom
 	cat config/packages > sbom/os.conf
 
 

--- a/tools/base_os_alpine/build/templates/makefiles/Makefile
+++ b/tools/base_os_alpine/build/templates/makefiles/Makefile
@@ -63,12 +63,12 @@ test_builder:
 public_build:  $(PAYLOAD_CONTAINER_FILE)
 	docker run --rm $(BUILDER_IMAGE) -a $(ARCH)  -b -s -t UTC -r v$(ALPINE_VERSION) -m $(REPO_URL)  -p $(PACKAGE_LIST)   > $(BUILD_DIR)/rootfs.tar.gz
 	cd $(BUILD_DIR) && docker build -t $(CONTAINER_IMAGE) -f Containerfile .
-	docker run --rm -i  --name alpine$(ALPINE_VERSION) $(CONTAINER_IMAGE)  /bin/sh -c 'apk info -v 2> /dev/null' > sbom/os.apk
+	docker run --rm -i  $(CONTAINER_IMAGE)  /bin/sh -c 'apk info -v 2> /dev/null' > sbom/os.apk
 
 private_build:  $(PAYLOAD_CONTAINER_FILE)
 	docker run -v "$$PWD/download/alpine/:/download"  --rm $(BUILDER_IMAGE)  -a  $(ARCH)   -b -s -t UTC -r v$(ALPINE_VERSION) -m /download -p $(PACKAGE_LIST)   > $(BUILD_DIR)/rootfs.tar.gz
 	cd $(BUILD_DIR) && docker build -t $(CONTAINER_IMAGE) -f Containerfile .
-	docker run --rm -i  --name alpine$(ALPINE_VERSION) $(CONTAINER_IMAGE) /bin/sh -c '/usr/local/bin/bom.sh 2> /dev/null' > sbom/os.bom
+	docker run --rm -i  $(CONTAINER_IMAGE) /bin/sh -c '/usr/local/bin/bom.sh 2> /dev/null' > sbom/os.bom
 	cat config/packages  > sbom/os.conf	
 
 

--- a/tools/base_os_alpine/build/templates/makefiles/Makefile.bootstrap
+++ b/tools/base_os_alpine/build/templates/makefiles/Makefile.bootstrap
@@ -41,7 +41,10 @@ $(TEST_MAKEFILE) :
 	echo "CONTAINER_IMAGE = \$$(BASE_OS_IMAGE):\$$(BASE_OS_VERSION)" >> $@
 	echo "" >> $@
 	echo "test:" >> $@
-	echo "\tdocker run   --rm  -i --entrypoint='/usr/local/bin/bom.sh'  --name alpine\$$(ALPINE_VERSION) \$$(CONTAINER_IMAGE) | tee os.bom" >> $@
+	echo "\tdocker run   --rm  -i --entrypoint='/usr/local/bin/bom.sh'   \$$(CONTAINER_IMAGE) | tee os.bom" >> $@
+	echo "" >> $@
+	echo "sh:" >> $@
+	echo "\tdocker run   --rm  -it    \$$(CONTAINER_IMAGE) sh " >> $@
 
 
 test: $(TEST_MAKEFILE)


### PR DESCRIPTION
Manage to build a repository with the reference implementation. 

Some packages is missing , also signing should use our own key. 

https://lb.t2data.com/alpine/v3.14/main/x86_64/

# Add entry in /etc/hosts

# Add entry in /etc/hosts
212.247.174.240 lb.t2data.com

Add entry in /etc/apk/repositories
https://lb.t2data.com/alpine/v3.14/main


# apk --update add  --allow-untrusted lighttpd
fetch https://lb.t2data.com/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
(1/9) Installing libbz2 (1.0.8-r1)
(2/9) Installing libev (4.33-r0)
(3/9) Installing gdbm (1.19-r0)
(4/9) Installing libsasl (2.1.27-r12)
(5/9) Installing libldap (2.4.58-r0)
(6/9) Installing lua5.3-libs (5.3.6-r0)
(7/9) Installing pcre (8.44-r0)
(8/9) Installing lighttpd (1.4.59-r0)
Executing lighttpd-1.4.59-r0.pre-install
(9/9) Installing lighttpd-openrc (1.4.59-r0)
Executing busybox-1.33.1-r6.trigger
OK: 18 MiB in 53 packages

