### PR TITLE
Extract legal dependencies

### DIFF
--- a/services/sbom_resolver/service/test/Makefile
+++ b/services/sbom_resolver/service/test/Makefile
@@ -100,8 +100,9 @@ python_index:
 	python3  ../build/bomres/bomres/lib/parse_apkbuild.py     --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --checkout /tmp/alpine/checkout   --cache      /tmp/alpine/cache
 
 pindex: 
-	rm -f /tmp/alpine/cache/*
-	python3  ../build/bomres/bomres/lib/parse_apkbuild.py     --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --checkout /tmp/alpine/checkout   --cache      /tmp/alpine/cache
+	python3  ../build/bomres/bomres/lib/aggregate_bom.py      --pkgindex $(PWD)/$(DIR)/build/base_os/sbom/apkindex.tar   --output   $(PWD)/$(DIR)/build/base_os/sbom/index.json
+	#rm -f /tmp/alpine/cache/*
+	#python3  ../build/bomres/bomres/lib/parse_apkbuild.py     --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --checkout /tmp/alpine/checkout   --cache      /tmp/alpine/cache
 
 python_resolve: 
 	python3  ../build/bomres/bomres/lib/resolve_bom.py   --packages $(PWD)/$(DIR)/build/base_os/sbom/aggregated.json   --cache /tmp/alpine/cache         --output $(PWD)/$(DIR)/build/base_os/sbom/resolved.json 


### PR DESCRIPTION
Extract information from APKINDEX hos packages are legaly integrated. 
Work in progress 

"struct": {
                "depend": {
                    "develop": [
                        "libc.musl-x86_64.so.1",
                        "libcrypto.so.1.1",
                        "libfreeradius-radius.so",
                        "libfreeradius-server.so",
                        "libgdbm.so.6",
                        "libpcap.so.1",
                        "libtalloc.so.2"
                    ],
                    "execute": [],
                    "file": [],
                    "package": []
                },
                "provide": {
                    "develop": [],
                    "execute": [
                        "rad_counter",
                        "radclient",
                        "radcrypt",
                        "radlast",
                        "radsniff",
                        "radsqlrelay",
                        "radtest",
                        "radwho",
                        "radzap",
                        "rlm_ippool_tool",
                        "rlm_sqlippool_tool",
                        "smbencrypt"
                    ],
                    "file": [
                        "freeradius-radclient",
                        "freeradius3-radclient"
                    ]
                }
            }
        },
