### PR TITLE
Improved extraction of dependency information

### DIFF
--- a/services/sbom_resolver/service/build/bomres/bomres/lib/create_apkcache.py
+++ b/services/sbom_resolver/service/build/bomres/bomres/lib/create_apkcache.py
@@ -142,7 +142,7 @@ def main():
     entry_exists, cache_index_file, aports_info, age = create_cache(
         args.src, pull_branch, args.checkout, args.cache, apk_index_dict)
 
-   # Dictionairy for parsing command line args and options.
+   # Dictionary for parsing command line args and options.
 args_options = {
     'opt':
     [

--- a/services/sbom_resolver/service/build/bomres/bomres/lib/parse_apkbuild.py
+++ b/services/sbom_resolver/service/build/bomres/bomres/lib/parse_apkbuild.py
@@ -947,6 +947,8 @@ def scan_aports(checkout_dir, apkindex):
                         stats['parse'][name] = parse_info
                     if len(temp) > 0:
                         result[name] = temp
+                        if name in apkindex['index'] and 'struct' in apkindex['index'][name]: 
+                           result[name]['struct'] = apkindex['index'][name]['struct']
                         if 'childs' in result[name]:
                             for child in result[name]['childs']:
                                 child_entry = {}

--- a/services/sbom_resolver/service/build/bomres/bomres/lib/resolve_bom.py
+++ b/services/sbom_resolver/service/build/bomres/bomres/lib/resolve_bom.py
@@ -158,6 +158,8 @@ def mapper(comp_dict, alpine_dict, debug=False):
                 else:
                     # Subpackages defined in aports
                     if alpine_dict['map'][prod]['parent'] != prod:
+                        if 'depend' in alpine_dict['map'][prod]:
+                            comp['aggregate']['depend'] = alpine_dict['map'][prod]['depend']
                         stats['children'] = stats['children'] + 1
                         comp['aggregate'] = {}
                         comp['aggregate']['parent'] = alpine_dict['map'][prod]['parent']
@@ -172,6 +174,10 @@ def mapper(comp_dict, alpine_dict, debug=False):
                     elif comp['pipeline']['aggregator']['alpine']['parent'] != prod:
                         stats['children'] = stats['children'] + 1
                         comp['aggregate']['info'] = {}
+
+                        if 'depend' in alpine_dict['map'][prod]:
+                            comp['aggregate']['depend'] = alpine_dict['map'][prod]['depend']
+
                         comp['aggregate']['info']['text'] = "This package is a subpackage of %s" % comp['pipeline']['aggregator']['alpine']['parent']
                         if debug:
                             sys.stdout.write("This is children of parent %s APKINDEX\n" %
@@ -183,6 +189,10 @@ def mapper(comp_dict, alpine_dict, debug=False):
                         comp['aggregate'] = {}
                         comp['aggregate']['match'] = 'product_version_match'
                         comp['aggregate']['parent'] = alpine_dict['map'][prod]['parent']
+
+                        if 'depend' in alpine_dict['map'][prod]:
+                            comp['aggregate']['depend'] = alpine_dict['map'][prod]['depend']
+
                         if 'download' in alpine_dict['map'][prod]:
                             comp['aggregate']['source'] = alpine_dict['map'][prod]['download']
                         if 'security' in alpine_dict['map'][prod]:


### PR DESCRIPTION
Resolved parent packaged based on shared library dependency in APKINDEX.tar.gz 


      {
            "ID": "native-lighttpd-1.4.59-r0-alpine-alpine_linux_3.14",
            "pipeline": {
                "domain": "linux",
                "product": "lighttpd",
                "target_sw": "alpine_linux_3.14",
                "vendor": "alpine",
                "version": "1.4.59",
                "update": "r0",
                "pkgrel": "0",
                "web_url": "https://www.lighttpd.net",
                "aggregator": {
                    "type": "alpine",
                    "match": true,
                    "alpine": {
                        "childs": [
                            "lighttpd-doc",
                            "lighttpd-dbg",
                            "lighttpd-mod_auth",
                            "lighttpd-mod_webdav",
                            "lighttpd-openrc"
                        ],
                        "pkgver": "1.4.59",
                        "pkgrel": "0",
                        "arch": "x86_64",
                        "parent": "lighttpd",
                        "commit": "6046223d4aa7db84c7b66c36a02443a16ae53312",
                        "repo": "main",
                        "tag": "v3.14",
                        "depends": {
                            "develop": {
                                "libbz2.so.1": "bzip2",
                                "libc.musl-x86_64.so.1": "musl",
                                "libcrypto.so.1.1": "openssl",
                                "libev.so.4": "libev",
                                "liblber-2.4.so.2": "openldap",
                                "libldap-2.4.so.2": "openldap",
                                "liblua-5.3.so.0": "lua5.3",
                                "libpcre.so.1": "pcre",
                                "libssl.so.1.1": "openssl",
                                "libz.so.1": "zlib"
                            }
                        }
                    }
                }
            },
