### PR TITLE
Busybox now builds

### DIFF
--- a/services/sbom_resolver/service/build/bomres/bomres/lib/aggregate_bom.py
+++ b/services/sbom_resolver/service/build/bomres/bomres/lib/aggregate_bom.py
@@ -299,18 +299,22 @@ def commit_map(result):
     if 'index' in result:
         for package in result['index']:
             if 'parent' in result['index'][package] and package == result['index'][package]['parent']:
+                repo = result['index'][package]['repo']
                 commit = result['index'][package]['commit']
+                tmp = {}
+                tmp['package'] = package
+                tmp['repo'] = repo
                 if commit in packages_commit:
-                    packages_commit[commit].append(package)
+                    packages_commit[commit].append(tmp)
                 else:
                     packages_commit[commit] = []
-                    packages_commit[commit].append(package)
+                    packages_commit[commit].append(tmp)
 
     result['commit_map'] = packages_commit
     return result
 
 
-def process_tarball(tarball, debug, create_commit_map=False):
+def process_tarball(tarball, debug, create_commit_map=True):
     dirpath = tempfile.mkdtemp()
     CWD = os.getcwd()
     os.chdir(dirpath)

--- a/services/sbom_resolver/service/build/entrypoint.sh
+++ b/services/sbom_resolver/service/build/entrypoint.sh
@@ -19,6 +19,16 @@ elif [ "$1" = 'index' ]; then
    # Combine information extracted from APKINDEX ( index.json ) and APORTS source , Output is a JSON with all info from APKINDEX and APORTS, named of hashed value of apkindex.tar
    exec sbom-resolver-parse_apkbuild --apkindex /sbom/index.json     --checkout /mnt/alpine/checkout   --cache      /mnt/alpine/cache 
 
+elif [ "$1" = 'deep' ]; then
+   # Input: tarball of all APKINDEX.tar.gz used in binary build , Output: One JSON file covering all packages used by the build 
+   sbom-resolver-aggregate_bom       --pkgindex /sbom/apkindex.tar   --output   /sbom/index.json 
+
+   # Checkout all APKINDEX files for each packages listed in index.json , Output: directory structure with all packages and APKINDEX with commit hash extension 
+   sbom-resolver-create_apkcache     --apkindex /sbom/index.json     --src      /mnt/alpine/src        --checkout   /mnt/alpine/checkout --cache /mnt/alpine/cache --deep
+
+   # Combine information extracted from APKINDEX ( index.json ) and APORTS source , Output is a JSON with all info from APKINDEX and APORTS, named of hashed value of apkindex.tar
+   exec sbom-resolver-parse_apkbuild --apkindex /sbom/index.json     --checkout /mnt/alpine/checkout   --cache      /mnt/alpine/cache 
+
 
 elif [ "$1" = 'tool' ]; then
    if [ "$#" -eq 1 ]; then
@@ -76,6 +86,7 @@ elif [ "$1" = 'help' ]; then
    echo "clone    :  Clone Alpine aports repository to local directory"
    echo "         :  Specify alternative path, default is https://git.alpinelinux.org/aports"
    echo "index    :  Create metadata needed for faster resolve "
+   echo "deep     :  Checkout aports package for each entry in apkindex "
    echo "server   :  Listen on port 8080 for HTTP requests , singlethread"
    echo "uwsgi    :  Listen on port 8080 for HTTP requests , multithread with uwsgi"
    echo "gunicorn :  Listen on port 8080 for HTTP requests , multithread with gunicorn"

--- a/services/sbom_resolver/service/test/Makefile
+++ b/services/sbom_resolver/service/test/Makefile
@@ -110,7 +110,7 @@ python_index:
 
 	# Checkout anc copy internal code, patches and APKBUILD from aports repository , directory structure in  /tmp/alpine/checkout 
         # Each repo tag is retrieved from index.json 
-	python3  ../build/bomres/bomres/lib/create_apkcache.py    --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --src      /tmp/alpine/src        --checkout   /tmp/alpine/checkout --cache /tmp/alpine/cache --debug
+	python3  ../build/bomres/bomres/lib/create_apkcache.py    --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --src      /tmp/alpine/src        --checkout   /tmp/alpine/checkout --cache /tmp/alpine/cache --debug --deep
 
         # Create /tmp/alpine/cache/APKINDEX-aa847b1b1602c1d767b7c58a148ff93c.json based on index.json and metadata from parsed aports data 
 	python3  ../build/bomres/bomres/lib/parse_apkbuild.py     --apkindex $(PWD)/$(DIR)/build/base_os/sbom/index.json     --checkout /tmp/alpine/checkout   --cache      /tmp/alpine/cache


### PR DESCRIPTION
There is now two options for linking between aports and apkindex. 
The quick and not so exact method of using the commit state of the repo , or the individual commit for each package. 
The later takes time. 

The problem occurs when building busybox, I added a section in resolved.json to indicate if the software stack is resolved. If not 
dependency are listed. 


 "resolver": {
            "status": false,
            "secondary": {
                "openssl": {
                    "libretls": [
                        "libcrypto.so.1.1",
                        "libssl.so.1.1"
                    ],
                    "apk-tools": [
                        "libcrypto.so.1.1",
                        "libssl.so.1.1"
                    ],
                    "lighttpd": [
                        "libcrypto.so.1.1",
                        "libssl.so.1.1"
                    ]
                },
                "brotli": {
