### PR TITLE
Added prodname_alias to resolved.json

### DIFF
--- a/services/sbom_resolver/service/build/bomres/bomres/lib/resolve_bom.py
+++ b/services/sbom_resolver/service/build/bomres/bomres/lib/resolve_bom.py
@@ -180,6 +180,9 @@ def mapper(comp_dict, alpine_dict, debug=False):
                         if 'repolink' in alpine_dict['map'][prod]:
                             comp['aggregate']['repolink'] = alpine_dict['map'][prod]['repolink']
 
+                        if 'pkgname_alias' in alpine_dict['map'][prod]:
+                            comp['aggregate']['pkgname_alias'] = alpine_dict['map'][prod]['pkgname_alias']
+
                         if 'depend' in alpine_dict['map'][prod]:
                             comp['aggregate']['depend'] = alpine_dict['map'][prod]['depend']
 


### PR DESCRIPTION
Alpine renames upstream package node_exporter to prometheus-node-exporter. 

We need both name to rebuild 

Complete SBOM ( resolved.json ) have new entry 

                "match": "product_version_match",
                "parent": "prometheus-node-exporter",
                "repolink": "repo",
                "pkgname_alias": "node_exporter",
